### PR TITLE
Try running the CI with python3 instead of python command

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -23,8 +23,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python3 -m pip3 install --upgrade pip
+        pip3 install -r requirements.txt
     - name: Run Tests
       run: |
-        python manage.py test
+        python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -48,5 +48,7 @@ jobs:
     #              run test suite
     #----------------------------------------------
     - name: Run Tests
-      source .venv/bin/activate
-      run: python3 manage.py test
+      
+      run: |
+        source .venv/bin/activate
+        python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -51,10 +51,6 @@ jobs:
     #              run test suite
     #----------------------------------------------
     - name: Run Tests
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       run: |
         source .venv/bin/activate
         python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -51,6 +51,8 @@ jobs:
     #              run test suite
     #----------------------------------------------
     - name: Run Tests
+      env: # Or as an environment variable
+        SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
       run: |
         source .venv/bin/activate
         python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -48,4 +48,5 @@ jobs:
     #              run test suite
     #----------------------------------------------
     - name: Run Tests
+      source .venv/bin/activate
       run: python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,8 +21,11 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+        
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.2
+      uses: dschep/install-poetry-action@v1.3
+      with:
+        create_virtualenvs: true
 
     - name: Cache Poetry virtualenv
       uses: actions/cache@v4

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -24,8 +24,8 @@ jobs:
       with:
         version: latest
         virtualenvs-create: true
-        virtualenvs-in-project: false
-        virtualenvs-path: ~/my-custom-path
+        virtualenvs-in-project: true
+        virtualenvs-path: ~/.venv
         installer-parallel: true
     - name: Load cached venv
       id: cached-poetry-dependencies

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -25,7 +25,7 @@ jobs:
       uses: dschep/install-poetry-action@v1.2
 
     - name: Cache Poetry virtualenv
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: cache
       with:
         path: ~/.virtualenvs
@@ -38,9 +38,9 @@ jobs:
         poetry config settings.virtualenvs.in-project false
         poetry config settings.virtualenvs.path ~/.virtualenvs
     
-    - name: Install Dependencies
+    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      name: Install Dependencies
       run: poetry install
-        if: steps.cache.outputs.cache-hit != 'true'
         
     - name: Run Tests
       run: |

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -23,8 +23,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
-        python3 -m pip3 install --upgrade pip
-        pip3 install -r requirements.txt
+        python3 -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: Run Tests
       run: |
         python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1
       with:
-        version: 2.1.3
+        version: latest
         virtualenvs-create: true
         virtualenvs-in-project: false
         virtualenvs-path: ~/my-custom-path
@@ -33,22 +33,27 @@ jobs:
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+    
     #----------------------------------------------
     # install dependencies if cache does not exist
     #----------------------------------------------
     - name: Install dependencies
       if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install --no-interaction --no-root
+    
     #----------------------------------------------
     # install your root project, if required
     #----------------------------------------------
     - name: Install project
       run: poetry install --no-interaction
+    
     #----------------------------------------------
     #              run test suite
     #----------------------------------------------
     - name: Run Tests
-      
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }
       run: |
         source .venv/bin/activate
         python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -51,6 +51,7 @@ jobs:
     #              run test suite
     #----------------------------------------------
     - name: Run Tests
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -21,10 +21,27 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
+    - name: Install Poetry
+      uses: dschep/install-poetry-action@v1.2
+
+    - name: Cache Poetry virtualenv
+      uses: actions/cache@v1
+      id: cache
+      with:
+        path: ~/.virtualenvs
+        key: poetry-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          poetry-${{ hashFiles('**/poetry.lock') }}
+
+    - name: Set Poetry config
       run: |
-        python3 -m pip install --upgrade pip
-        pip install -r requirements.txt
+        poetry config settings.virtualenvs.in-project false
+        poetry config settings.virtualenvs.path ~/.virtualenvs
+    
+    - name: Install Dependencies
+      run: poetry install
+        if: steps.cache.outputs.cache-hit != 'true'
+        
     - name: Run Tests
       run: |
         python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -8,20 +8,17 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.13]
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
-        
+        python-version: ${{ matrix.python-version }}      
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1
       with:
@@ -30,14 +27,12 @@ jobs:
         virtualenvs-in-project: false
         virtualenvs-path: ~/my-custom-path
         installer-parallel: true
-
     - name: Load cached venv
       id: cached-poetry-dependencies
       uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-        
     #----------------------------------------------
     # install dependencies if cache does not exist
     #----------------------------------------------
@@ -47,11 +42,10 @@ jobs:
     #----------------------------------------------
     # install your root project, if required
     #----------------------------------------------
-  - name: Install project
+    - name: Install project
       run: poetry install --no-interaction
     #----------------------------------------------
     #              run test suite
     #----------------------------------------------
-  - name: Run Tests
-    run: |
-      python3 manage.py test
+    - name: Run Tests
+      run: python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Run Tests
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       run: |
         source .venv/bin/activate
         python3 manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}      
     - name: Install and configure Poetry
-      uses: snok/install-poetry@v1
+      uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
       with:
         version: latest
         virtualenvs-create: true

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,29 +22,36 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         
-    - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.3
+    - name: Install and configure Poetry
+      uses: snok/install-poetry@v1
       with:
-        create_virtualenvs: true
+        version: 2.1.3
+        virtualenvs-create: true
+        virtualenvs-in-project: false
+        virtualenvs-path: ~/my-custom-path
+        installer-parallel: true
 
-    - name: Cache Poetry virtualenv
+    - name: Load cached venv
+      id: cached-poetry-dependencies
       uses: actions/cache@v4
-      id: cache
       with:
-        path: ~/.virtualenvs
-        key: poetry-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: |
-          poetry-${{ hashFiles('**/poetry.lock') }}
-
-    - name: Set Poetry config
-      run: |
-        poetry config settings.virtualenvs.in-project false
-        poetry config settings.virtualenvs.path ~/.virtualenvs
-    
-    - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-      name: Install Dependencies
-      run: poetry install
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
         
-    - name: Run Tests
-      run: |
-        python3 manage.py test
+    #----------------------------------------------
+    # install dependencies if cache does not exist
+    #----------------------------------------------
+    - name: Install dependencies
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction --no-root
+    #----------------------------------------------
+    # install your root project, if required
+    #----------------------------------------------
+  - name: Install project
+      run: poetry install --no-interaction
+    #----------------------------------------------
+    #              run test suite
+    #----------------------------------------------
+  - name: Run Tests
+    run: |
+      python3 manage.py test


### PR DESCRIPTION
Since the last run failed "ModuleNotFoundError: No module named 'environ'" Error which is attributed to some python venv shenanigans, we retry by running the python3 command explicitly.